### PR TITLE
Fix handling of dashes in the style directory path

### DIFF
--- a/Telegram/SourceFiles/codegen/style/generator.cpp
+++ b/Telegram/SourceFiles/codegen/style/generator.cpp
@@ -1186,9 +1186,11 @@ QByteArray iconMaskValueSize(int width, int height) {
 QByteArray iconMaskValuePng(QString filepath) {
 	QByteArray result;
 
-	auto pathAndModifiers = filepath.split('-');
-	filepath = pathAndModifiers[0];
-	auto modifiers = pathAndModifiers.mid(1);
+	QFileInfo fileInfo(filepath);
+	auto directory = fileInfo.dir();
+	auto nameAndModifiers = fileInfo.fileName().split('-');
+	filepath = directory.filePath(nameAndModifiers[0]);
+	auto modifiers = nameAndModifiers.mid(1);
 
 	QImage png100x(filepath + ".png");
 	QImage png200x(filepath + "@2x.png");


### PR DESCRIPTION
Fixes #52 for me.

There're still places where dashes _could_ cause problems (full list mentioned in #52), but they're not triggering any errors in my environment. Probably they're either unused or doesn't get called with full paths (and only with file names that's "safe").