### PR TITLE
Allow unicode quotes as markdown entry separators

### DIFF
--- a/Telegram/SourceFiles/ui/text/text_entity.cpp
+++ b/Telegram/SourceFiles/ui/text/text_entity.cpp
@@ -44,7 +44,9 @@ QString ExpressionMailNameAtEnd() {
 }
 
 QString ExpressionSeparators(const QString &additional) {
-	return qsl("\\s\\.,:;<>|'\"\\[\\]\\{\\}\\~\\!\\?\\%\\^\\(\\)\\-\\+=\\x10") + additional;
+	// UTF8 quotes: «»“”‘’
+	const auto quotes = QString::fromUtf8("\xC2\xAB\xC2\xBB\xE2\x80\x9C\xE2\x80\x9D\xE2\x80\x98\xE2\x80\x99");
+	return qsl("\\s\\.,:;<>|'\"\\[\\]\\{\\}\\~\\!\\?\\%\\^\\(\\)\\-\\+=\\x10") + quotes + additional;
 }
 
 QString ExpressionHashtag() {


### PR DESCRIPTION
Closes #13.

This was cherry-picked from upstream's commit https://github.com/telegramdesktop/tdesktop/commit/2e421e8aede67a73e2901137a2a44544fa26d3b7, but significantly reworked afterwards.