### PR TITLE
Use custom application name in tray popup menu

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -37,10 +37,10 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 
 "lng_disable_notifications_from_tray" = "Disable notifications";
 "lng_enable_notifications_from_tray" = "Enable notifications";
-"lng_open_from_tray" = "Open Telegram";
+"lng_open_from_tray" = "Open {appname}";
 "lng_minimize_to_tray" = "Minimize to tray";
-"lng_quit_from_tray" = "Quit Telegram";
-"lng_tray_icon_text" = "Telegram is still running here,\nyou can change this from settings page.\nIf this icon disappears from tray menu,\nyou can drag it here from hidden icons.";
+"lng_quit_from_tray" = "Quit {appname}";
+"lng_tray_icon_text" = "{appname} is still running here,\nyou can change this from settings page.\nIf this icon disappears from tray menu,\nyou can drag it here from hidden icons.";
 
 "lng_month1" = "January";
 "lng_month2" = "February";
@@ -1427,6 +1427,6 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 "lng_mac_menu_add_contact" = "Add Contact";
 "lng_mac_menu_new_group" = "New Group";
 "lng_mac_menu_new_channel" = "New Channel";
-"lng_mac_menu_show" = "Show Telegram";
+"lng_mac_menu_show" = "Show {telegram}";
 
 // Keys finished

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1427,6 +1427,6 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 "lng_mac_menu_add_contact" = "Add Contact";
 "lng_mac_menu_new_group" = "New Group";
 "lng_mac_menu_new_channel" = "New Channel";
-"lng_mac_menu_show" = "Show {telegram}";
+"lng_mac_menu_show" = "Show Telegram";
 
 // Keys finished

--- a/Telegram/SourceFiles/mainwindow.cpp
+++ b/Telegram/SourceFiles/mainwindow.cpp
@@ -166,14 +166,14 @@ void MainWindow::firstShow() {
 		: lng_enable_notifications_from_tray);
 
 	if (isLinux) {
-		trayIconMenu->addAction(lang(lng_open_from_tray), this, SLOT(showFromTray()))->setEnabled(true);
+		trayIconMenu->addAction(lng_open_from_tray(lt_appname, lang(appname)), this, SLOT(showFromTray()))->setEnabled(true);
 		trayIconMenu->addAction(lang(lng_minimize_to_tray), this, SLOT(minimizeToTray()))->setEnabled(true);
 		trayIconMenu->addAction(notificationActionText, this, SLOT(toggleDisplayNotifyFromTray()))->setEnabled(true);
-		trayIconMenu->addAction(lang(lng_quit_from_tray), this, SLOT(quitFromTray()))->setEnabled(true);
+		trayIconMenu->addAction(lng_quit_from_tray(lt_appname, lang(appname)), this, SLOT(quitFromTray()))->setEnabled(true);
 	} else {
 		trayIconMenu->addAction(lang(lng_minimize_to_tray), this, SLOT(minimizeToTray()))->setEnabled(true);
 		trayIconMenu->addAction(notificationActionText, this, SLOT(toggleDisplayNotifyFromTray()))->setEnabled(true);
-		trayIconMenu->addAction(lang(lng_quit_from_tray), this, SLOT(quitFromTray()))->setEnabled(true);
+		trayIconMenu->addAction(lng_quit_from_tray(lt_appname, lang(appname)), this, SLOT(quitFromTray()))->setEnabled(true);
 	}
 	Global::RefWorkMode().setForced(Global::WorkMode().value(), true);
 
@@ -610,7 +610,7 @@ void MainWindow::updateTrayMenu(bool force) {
 		disconnect(toggleAction, SIGNAL(triggered(bool)), this, SLOT(minimizeToTray()));
 		disconnect(toggleAction, SIGNAL(triggered(bool)), this, SLOT(showFromTray()));
 		connect(toggleAction, SIGNAL(triggered(bool)), this, active ? SLOT(minimizeToTray()) : SLOT(showFromTray()));
-		toggleAction->setText(lang(active ? lng_minimize_to_tray : lng_open_from_tray));
+		toggleAction->setText(active ? lang(lng_minimize_to_tray) : lng_open_from_tray(lt_appname, lang(appname)));
 
 		// On macOS just remove trayIcon menu if the window is not active.
 		// So we will activate the window on click instead of showing the menu.

--- a/Telegram/SourceFiles/platform/win/main_window_win.cpp
+++ b/Telegram/SourceFiles/platform/win/main_window_win.cpp
@@ -685,7 +685,7 @@ void MainWindow::psSetupTrayIcon() {
 
 void MainWindow::showTrayTooltip() {
 	if (trayIcon && !cSeenTrayTooltip()) {
-		trayIcon->showMessage(str_const_toString(AppName), lang(lng_tray_icon_text), QSystemTrayIcon::Information, 10000);
+		trayIcon->showMessage(str_const_toString(AppName), lng_tray_icon_text(lt_appname, lang(appname)), QSystemTrayIcon::Information, 10000);
 		cSetSeenTrayTooltip(true);
 		Local::writeSettings();
 	}


### PR DESCRIPTION
- Use parameter {appname} for tray icon lang strings
- Update mainwindow.cpp to use parametrized lang calls

Should I update other lang files like lang_de.strings?
"lng_mac_menu_show" change in mac specific section may be unrelated, cannot test with MacOS