### PR TITLE
Completely remove Unity support

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -10,7 +10,6 @@ endif()
 if (PACKAGED_BUILD)
     add_definitions(-DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME)
     add_definitions(-DTDESKTOP_DISABLE_DESKTOP_FILE_GENERATION)
-    add_definitions(-DTDESKTOP_DISABLE_UNITY_INTEGRATION)
 endif()
 
 ##================================================
@@ -592,7 +591,6 @@ add_definitions(-DAL_ALEXT_PROTOTYPES)
 add_definitions(-DTGVOIP_USE_CXX11_LIB)
 
 add_definitions(-DTDESKTOP_DISABLE_CRASH_REPORTS)
-add_definitions(-DTDESKTOP_DISABLE_UNITY_INTEGRATION) # Linux only
 
 if (LINUX)
     add_definitions(-D_REENTRANT)

--- a/Telegram/SourceFiles/platform/linux/linux_libs.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_libs.cpp
@@ -47,25 +47,10 @@ bool loadLibrary(QLibrary &lib, const char *name, int version) {
 
 } // namespace
 
-#ifndef TDESKTOP_DISABLE_UNITY_INTEGRATION
-f_unity_launcher_entry_set_count unity_launcher_entry_set_count = nullptr;
-f_unity_launcher_entry_set_count_visible unity_launcher_entry_set_count_visible = nullptr;
-f_unity_launcher_entry_get_for_desktop_id unity_launcher_entry_get_for_desktop_id = nullptr;
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 
 void start() {
 	DEBUG_LOG(("Loading libraries"));
 
-#ifndef TDESKTOP_DISABLE_UNITY_INTEGRATION
-	if (DesktopEnvironment::TryUnityCounter()) {
-		QLibrary lib_unity(qstr("unity"), 9, 0);
-		loadLibrary(lib_unity, "unity", 9);
-
-		load(lib_unity, "unity_launcher_entry_get_for_desktop_id", unity_launcher_entry_get_for_desktop_id);
-		load(lib_unity, "unity_launcher_entry_set_count", unity_launcher_entry_set_count);
-		load(lib_unity, "unity_launcher_entry_set_count_visible", unity_launcher_entry_set_count_visible);
-	}
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 }
 
 } // namespace Libs

--- a/Telegram/SourceFiles/platform/linux/linux_libs.h
+++ b/Telegram/SourceFiles/platform/linux/linux_libs.h
@@ -20,9 +20,6 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 */
 #pragma once
 
-#ifndef TDESKTOP_DISABLE_UNITY_INTEGRATION
-#include <unity/unity/unity.h>
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 
 namespace Platform {
 namespace Libs {
@@ -44,16 +41,6 @@ bool load(QLibrary &lib, const char *name, Function &func) {
 	return false;
 }
 
-#ifndef TDESKTOP_DISABLE_UNITY_INTEGRATION
-typedef void (*f_unity_launcher_entry_set_count)(UnityLauncherEntry* self, gint64 value);
-extern f_unity_launcher_entry_set_count unity_launcher_entry_set_count;
-
-typedef void (*f_unity_launcher_entry_set_count_visible)(UnityLauncherEntry* self, gboolean value);
-extern f_unity_launcher_entry_set_count_visible unity_launcher_entry_set_count_visible;
-
-typedef UnityLauncherEntry* (*f_unity_launcher_entry_get_for_desktop_id)(const gchar* desktop_id);
-extern f_unity_launcher_entry_get_for_desktop_id unity_launcher_entry_get_for_desktop_id;
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 
 } // namespace Libs
 } // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -107,9 +107,6 @@ QString _trayIconImageFile() {
 	return QString();
 }
 
-#ifndef TDESKTOP_DISABLE_UNITY_INTEGRATION
-UnityLauncherEntry *_psUnityLauncherEntry = nullptr;
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 
 } // namespace
 
@@ -207,16 +204,6 @@ void MainWindow::updateIconCounters() {
 
 	auto counter = App::histories().unreadBadge();
 
-#if !defined(TDESKTOP_DISABLE_UNITY_INTEGRATION)
-	if (_psUnityLauncherEntry) {
-		if (counter > 0) {
-			Libs::unity_launcher_entry_set_count(_psUnityLauncherEntry, (counter > 9999) ? 9999 : counter);
-			Libs::unity_launcher_entry_set_count_visible(_psUnityLauncherEntry, TRUE);
-		} else {
-			Libs::unity_launcher_entry_set_count_visible(_psUnityLauncherEntry, FALSE);
-		}
-	}
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 
 	if (noQtTrayIcon) {
 	} else if (trayIcon) {
@@ -245,14 +232,6 @@ void MainWindow::LibsLoaded() {
 
 	if (noQtTrayIcon) cSetSupportTray(false);
 
-#ifndef TDESKTOP_DISABLE_UNITY_INTEGRATION
-	useUnityCount = (Libs::unity_launcher_entry_get_for_desktop_id != nullptr)
-			&& (Libs::unity_launcher_entry_set_count != nullptr)
-			&& (Libs::unity_launcher_entry_set_count_visible != nullptr);
-	if (useUnityCount) {
-		DEBUG_LOG(("Unity count api loaded!"));
-	}
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 }
 
 void MainWindow::psCreateTrayIcon() {
@@ -266,23 +245,6 @@ void MainWindow::psCreateTrayIcon() {
 void MainWindow::psFirstShow() {
 	psCreateTrayIcon();
 
-#if !defined(TDESKTOP_DISABLE_UNITY_INTEGRATION)
-	if (useUnityCount) {
-		_psUnityLauncherEntry = Libs::unity_launcher_entry_get_for_desktop_id("telegramdesktop.desktop");
-		if (_psUnityLauncherEntry) {
-			LOG(("Found Unity Launcher entry telegramdesktop.desktop!"));
-		} else {
-			_psUnityLauncherEntry = Libs::unity_launcher_entry_get_for_desktop_id("Telegram.desktop");
-			if (_psUnityLauncherEntry) {
-				LOG(("Found Unity Launcher entry Telegram.desktop!"));
-			} else {
-				LOG(("Could not get Unity Launcher entry!"));
-			}
-		}
-	} else {
-		LOG(("Not using Unity Launcher count."));
-	}
-#endif // !TDESKTOP_DISABLE_UNITY_INTEGRATION
 
 	psUpdateMargins();
 
@@ -317,12 +279,6 @@ void MainWindow::psUpdateMargins() {
 }
 
 MainWindow::~MainWindow() {
-#ifndef TDESKTOP_DISABLE_UNITY_INTEGRATION
-	if (_psUnityLauncherEntry) {
-		Libs::g_object_unref(_psUnityLauncherEntry);
-		_psUnityLauncherEntry = nullptr;
-	}
-#endif // ! TDESKTOP_DISABLE_UNITY_INTEGRATION
 }
 
 } // namespace Platform


### PR DESCRIPTION
Unity is no longer supported by Canonical and will be excluded from Ubuntu 18.04 LTS.