### PR TITLE
Minimum required cmake version check

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Specify minimum cmake version
+    cmake_minimum_required(VERSION 3.10)
 # defines
 if (LINUX)
     if (CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
CMake Warning (dev) in CMakeLists.txt:
  No cmake_minimum_required command is present.
