### PR TITLE
Add libreSSL support

### DIFF
--- a/Telegram/SourceFiles/mtproto/rsa_public_key.cpp
+++ b/Telegram/SourceFiles/mtproto/rsa_public_key.cpp
@@ -30,7 +30,7 @@ using std::string;
 
 namespace MTP {
 namespace {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 // This is a key setter for compatibility with OpenSSL 1.0
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {


### PR DESCRIPTION
Also check LIBRESSL_VERSION_NUMBER and if it's defined, we use the LibreSSL-compatible API calls.