### PR TITLE
Prepare SPEC to 2.0.0 final release

### DIFF
--- a/kepka.spec
+++ b/kepka.spec
@@ -1,26 +1,22 @@
 Name: kepka
-Version: 1.0.0
+Version: 2.0.0
 Release: 1%{?dist}
 
 License: GPLv3+
 Summary: Unofficial Telegram desktop messaging app
-Group: Applications/Internet
 URL: https://github.com/procxx/%{name}
+Source0: %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 ExclusiveArch: i686 x86_64
 
-Source0: %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-
+# Additional runtime requirements...
 Requires: qt5-qtimageformats%{?_isa}
 Requires: hicolor-icon-theme
-Requires: gtk3%{?_isa}
-Recommends: libappindicator-gtk3%{?_isa}
 
 # Compilers and tools...
 BuildRequires: desktop-file-utils
 BuildRequires: libappstream-glib
 BuildRequires: ninja-build
 BuildRequires: gcc-c++
-BuildRequires: chrpath
 BuildRequires: cmake
 BuildRequires: gcc
 
@@ -44,59 +40,52 @@ BuildRequires: pulseaudio-libs-devel
 BuildRequires: alsa-lib-devel
 
 %description
-Telegram is a messaging app with a focus on speed and security, it’s super
-fast, simple and free. You can use Telegram on all your devices at the same
+Kepka is a messaging app with a focus on speed and security, it’s super
+fast, simple and free. You can use Kepka on all your devices at the same
 time — your messages sync seamlessly across any of your phones, tablets or
 computers.
 
-With Telegram, you can send messages, photos, videos and files of any type
+With Kepka you can send messages, photos, videos and files of any type
 (doc, zip, mp3, etc), as well as create groups for up to 200 people. You can
 write to your phone contacts and find people by their usernames. As a result,
-Telegram is like SMS and email combined — and can take care of all your
+Kepka is like SMS and email combined — and can take care of all your
 personal or business messaging needs.
 
 %prep
 # Unpacking main source archive...
 %autosetup -p1
-mkdir %{_target_platform}
+mkdir -p %{_target_platform}
 
 %build
-# Building application...
+# Configuring application...
 pushd %{_target_platform}
     %cmake -G Ninja -DPACKAGED_BUILD=1 -DCMAKE_BUILD_TYPE=Release ..
-    %ninja_build
 popd
 
+# Building application...
+%ninja_build -C %{_target_platform}
+
 %install
-# Installing executables...
-mkdir -p "%{buildroot}%{_bindir}"
-install -m 0755 -p %{_target_platform}/Telegram/Telegram "%{buildroot}%{_bindir}/%{name}"
-
-# Installing desktop shortcut...
-desktop-file-install --dir="%{buildroot}%{_datadir}/applications" lib/xdg/%{name}.desktop
-
-# Installing icons...
-for size in 16 32 48 64 128 256 512; do
-    dir="%{buildroot}%{_datadir}/icons/hicolor/${size}x${size}/apps"
-    install -d "$dir"
-    install -m 0644 -p Telegram/Resources/art/icon${size}.png "$dir/%{name}.png"
-done
-
-# Installing appdata for Gnome Software...
-install -d "%{buildroot}%{_datadir}/metainfo"
-install -m 0644 -p lib/xdg/%{name}.appdata.xml "%{buildroot}%{_datadir}/metainfo/%{name}.appdata.xml"
+# Installing application...
+%ninja_install -C %{_target_platform}
 
 %check
-appstream-util validate-relax --nonet "%{buildroot}%{_datadir}/metainfo/%{name}.appdata.xml"
+# Checking AppStream manifest and desktop file...
+appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/%{name}.appdata.xml
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 %files
-%doc README.md changelog.txt
+%doc README.md
 %license LICENSE
 %{_bindir}/%{name}
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/*/apps/%{name}.png
+%{_datadir}/kservices5/tg.protocol
 %{_datadir}/metainfo/%{name}.appdata.xml
 
 %changelog
+* Fri Jul 27 2018 Vitaly Zaitsev <vitaly@easycoding.org> - 2.0.0-1
+- Updated to version 2.0.0.
+
 * Thu Dec 21 2017 Vitaly Zaitsev <vitaly@easycoding.org> - 1.0.0-1
 - Initial SPEC release.


### PR DESCRIPTION
Prepare SPEC to 2.0.0 final release:
 * update version;
 * removed no longer required dependencies;
 * fixed description of package;
 * switch to automatic installation;
 * added missing protocol handler.