### PR TITLE
OS X build fixes

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -714,7 +714,9 @@ target_link_libraries(Kepka Threads::Threads)
 include(GNUInstallDirs)
 
 set_target_properties(Kepka PROPERTIES OUTPUT_NAME "kepka")
-install(TARGETS Kepka RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS Kepka
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES "${CMAKE_SOURCE_DIR}/lib/xdg/kepka.desktop"
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications

--- a/Telegram/SourceFiles/backports/is_invocable.h
+++ b/Telegram/SourceFiles/backports/is_invocable.h
@@ -1,3 +1,21 @@
+/* Extracted from https://github.com/facebook/folly/blob/master/folly/functional/Invoke.h */
+
+/*
+ * Copyright 2017-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <functional>

--- a/Telegram/SourceFiles/backports/is_invocable.h
+++ b/Telegram/SourceFiles/backports/is_invocable.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <functional>
+#include <type_traits>
+
+#if __cpp_lib_is_invocable >= 201703 || (_MSC_VER >= 1911 && _MSVC_LANG > 201402)
+
+namespace backports {
+
+/* using override */ using std::invoke_result;
+/* using override */ using std::invoke_result_t;
+/* using override */ using std::is_invocable;
+/* using override */ using std::is_invocable_r;
+/* using override */ using std::is_invocable_r_v;
+/* using override */ using std::is_invocable_v;
+/* using override */ using std::is_nothrow_invocable;
+/* using override */ using std::is_nothrow_invocable_r;
+/* using override */ using std::is_nothrow_invocable_r_v;
+/* using override */ using std::is_nothrow_invocable_v;
+
+} // namespace backports
+
+#else
+
+namespace backports {
+
+namespace invoke_detail {
+
+template <bool... Bs> struct Bools {
+	using valid_type = bool;
+	static constexpr std::size_t size() {
+		return sizeof...(Bs);
+	}
+};
+
+template <typename T> struct Negation : std::bool_constant<!T::value> {};
+
+// Lighter-weight than Conjunction, but evaluates all sub-conditions eagerly.
+template <class... Ts> struct StrictConjunction : std::is_same<Bools<Ts::value...>, Bools<(Ts::value || true)...>> {};
+
+template <class... Ts>
+struct StrictDisjunction : Negation<std::is_same<Bools<Ts::value...>, Bools<(Ts::value && false)...>>> {};
+
+template <typename F, typename... Args>
+using invoke_result_ = decltype(std::invoke(std::declval<F>(), std::declval<Args>()...));
+
+template <typename F, typename... Args>
+struct invoke_nothrow_ : std::bool_constant<noexcept(std::invoke(std::declval<F>(), std::declval<Args>()...))> {};
+
+//  from: http://en.cppreference.com/w/cpp/types/result_of, CC-BY-SA
+
+template <typename Void, typename F, typename... Args> struct invoke_result {};
+
+template <typename F, typename... Args> struct invoke_result<std::void_t<invoke_result_<F, Args...>>, F, Args...> {
+	using type = invoke_result_<F, Args...>;
+};
+
+template <typename Void, typename F, typename... Args> struct is_invocable : std::false_type {};
+
+template <typename F, typename... Args>
+struct is_invocable<std::void_t<invoke_result_<F, Args...>>, F, Args...> : std::true_type {};
+
+template <typename Void, typename R, typename F, typename... Args> struct is_invocable_r : std::false_type {};
+
+template <typename R, typename F, typename... Args>
+struct is_invocable_r<std::void_t<invoke_result_<F, Args...>>, R, F, Args...>
+    : std::is_convertible<invoke_result_<F, Args...>, R> {};
+
+template <typename Void, typename F, typename... Args> struct is_nothrow_invocable : std::false_type {};
+
+template <typename F, typename... Args>
+struct is_nothrow_invocable<std::void_t<invoke_result_<F, Args...>>, F, Args...> : invoke_nothrow_<F, Args...> {};
+
+template <typename Void, typename R, typename F, typename... Args> struct is_nothrow_invocable_r : std::false_type {};
+
+template <typename R, typename F, typename... Args>
+struct is_nothrow_invocable_r<std::void_t<invoke_result_<F, Args...>>, R, F, Args...>
+    : StrictConjunction<std::is_convertible<invoke_result_<F, Args...>, R>, invoke_nothrow_<F, Args...>> {};
+
+} // namespace invoke_detail
+
+//  mimic: std::invoke_result, C++17
+template <typename F, typename... Args> struct invoke_result : invoke_detail::invoke_result<void, F, Args...> {};
+
+//  mimic: std::invoke_result_t, C++17
+template <typename F, typename... Args> using invoke_result_t = typename invoke_result<F, Args...>::type;
+
+//  mimic: std::is_invocable, C++17
+template <typename F, typename... Args> struct is_invocable : invoke_detail::is_invocable<void, F, Args...> {};
+
+//  mimic: std::is_invocable_r, C++17
+template <typename R, typename F, typename... Args>
+struct is_invocable_r : invoke_detail::is_invocable_r<void, R, F, Args...> {};
+
+//  mimic: std::is_nothrow_invocable, C++17
+template <typename F, typename... Args>
+struct is_nothrow_invocable : invoke_detail::is_nothrow_invocable<void, F, Args...> {};
+
+//  mimic: std::is_nothrow_invocable_r, C++17
+template <typename R, typename F, typename... Args>
+struct is_nothrow_invocable_r : invoke_detail::is_nothrow_invocable_r<void, R, F, Args...> {};
+
+template <class Fn, class... ArgTypes> inline constexpr bool is_invocable_v = is_invocable<Fn, ArgTypes...>::value;
+
+template <class R, class Fn, class... ArgTypes>
+inline constexpr bool is_invocable_r_v = is_invocable_r<R, Fn, ArgTypes...>::value;
+
+template <class Fn, class... ArgTypes>
+inline constexpr bool is_nothrow_invocable_v = is_nothrow_invocable<Fn, ArgTypes...>::value;
+
+template <class R, class Fn, class... ArgTypes>
+inline constexpr bool is_nothrow_invocable_r_v = is_nothrow_invocable_r<R, Fn, ArgTypes...>::value;
+
+} // namespace backports
+
+#endif

--- a/Telegram/SourceFiles/mtproto/rpc_sender.h
+++ b/Telegram/SourceFiles/mtproto/rpc_sender.h
@@ -23,6 +23,7 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 #include "base/lambda_guard.h"
 #include "core/basic_types.h"
 #include "core/utils.h"
+#include "backports/is_invocable.h"
 #include "scheme.h"
 #include <QSet>
 #include <QString>
@@ -938,14 +939,15 @@ public:
 };
 
 template <typename Lambda>
-constexpr bool rpcDone_canCallBare_v = std::is_invocable_v<Lambda, const mtpPrime *, const mtpPrime *>;
+constexpr bool rpcDone_canCallBare_v = backports::is_invocable_v<Lambda, const mtpPrime *, const mtpPrime *>;
 
 template <typename Lambda>
-constexpr bool rpcDone_canCallBareReq_v = std::is_invocable_v<Lambda, const mtpPrime *, const mtpPrime *, mtpRequestId>;
+constexpr bool rpcDone_canCallBareReq_v =
+    backports::is_invocable_v<Lambda, const mtpPrime *, const mtpPrime *, mtpRequestId>;
 
-template <typename Lambda> constexpr bool rpcDone_canCallNo_v = std::is_invocable_v<Lambda>;
+template <typename Lambda> constexpr bool rpcDone_canCallNo_v = backports::is_invocable_v<Lambda>;
 
-template <typename Lambda> constexpr bool rpcDone_canCallNoReq_v = std::is_invocable_v<Lambda, mtpRequestId>;
+template <typename Lambda> constexpr bool rpcDone_canCallNoReq_v = backports::is_invocable_v<Lambda, mtpRequestId>;
 
 template <typename Function> struct rpcDone_canCallPlain : std::false_type {};
 
@@ -1044,14 +1046,14 @@ public:
 	}
 };
 
-template <typename Lambda> constexpr bool rpcFail_canCallNo_v = std::is_invocable_v<Lambda>;
+template <typename Lambda> constexpr bool rpcFail_canCallNo_v = backports::is_invocable_v<Lambda>;
 
-template <typename Lambda> constexpr bool rpcFail_canCallNoReq_v = std::is_invocable_v<Lambda, mtpRequestId>;
+template <typename Lambda> constexpr bool rpcFail_canCallNoReq_v = backports::is_invocable_v<Lambda, mtpRequestId>;
 
-template <typename Lambda> constexpr bool rpcFail_canCallPlain_v = std::is_invocable_v<Lambda, const RPCError &>;
+template <typename Lambda> constexpr bool rpcFail_canCallPlain_v = backports::is_invocable_v<Lambda, const RPCError &>;
 
 template <typename Lambda>
-constexpr bool rpcFail_canCallReq_v = std::is_invocable_v<Lambda, const RPCError &, mtpRequestId>;
+constexpr bool rpcFail_canCallReq_v = backports::is_invocable_v<Lambda, const RPCError &, mtpRequestId>;
 
 template <typename Lambda, typename Function = base::lambda_call_type_t<Lambda>>
 RPCFailHandlerPtr rpcFail(Lambda lambda) {


### PR DESCRIPTION
- Added BUNDLE DESTINATION to make cmake happy
- Used `is_invocable_v` backport from folly, since apple-clang doesn't have one in `std::` yet