### PR TITLE
Removed AL_LIBTYPE_STATIC build definition

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -565,7 +565,6 @@ if (WIN32)
         -DHAVE_STDINT_H -DNOMINMAX)
 endif()
 
-add_definitions(-DAL_LIBTYPE_STATIC)
 add_definitions(-DAL_ALEXT_PROTOTYPES)
 
 if (LINUX)


### PR DESCRIPTION
Kepka is built against packaged version of OpenAL, so we don't need this.