### PR TITLE
Added PACKAGED_BUILD cmake build option to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if (CCACHE)
 endif()
 
 option(ENABLE_IPO "Enable IPO optimizations." OFF)
+option(PACKAGED_BUILD "Enable packaged build." OFF)
 
 option(BUILD_DOC "Build documentation" OFF)
 mark_as_advanced(BUILD_DOC)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is the complete source code and the build instructions for the Kepka's alph
  - clang-format;
  - fix almost all warnings;
  - optional inter-procedural optimizations on \*nix (can be enabled by forwarding CMake's `-DENABLE_IPO:BOOL=ON` flag; improves performance but could significantly increase compilation times);
+ - optional packaged build for GNU/Linux maintainers (can be enabled by forwarding CMake's `-DPACKAGED_BUILD:BOOL=ON` flag; will disable automatic schema registration and icon generation);
 * Ability to toggle "typographical" replaces (like replace << to « and another);
 * Packages for Fedora and Arch Linux (packages for Debian and Ubuntu will be done soon);
 * UI based on 1.1.21 before UI "mobilization" which degrades UX (e.g. group settings will be accessible from 5 clicks);


### PR DESCRIPTION
This option disabled by default. GNU/Linux maintainers can enable it by forwarding `-DPACKAGED_BUILD:BOOL=ON` cmake build flag.

Automatic schema registration and icon generation will be permanently disabled.