### PR TITLE
Allow to forward custom API tokens for Kepka

### DIFF
--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,11 +1,21 @@
 $ErrorActionPreference = 'Stop'
 
 Push-Location "$env:APPVEYOR_BUILD_FOLDER\build"
+
+function execute-cmake {
+    # We have to merge the stderr and stdout here because otherwise the build will fail on any random warning
+    cmd /c 'cmake 2>&1' @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "CMake execution error: $LASTEXITCODE"
+    }
+}
+
 try {
-    cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-    if (!$?) { throw 'Error running cmake' }
-    cmake --build . --config RelWithDebInfo
-    if (!$?) { throw 'Error building with cmake' }
+    execute-cmake '-GNinja' `
+        '-DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake' `
+        '-DCMAKE_BUILD_TYPE=RelWithDebInfo' `
+        ..
+    execute-cmake --build . --config RelWithDebInfo
     ctest .
     if (!$?) { throw 'ctest execution error' }
 } finally {

--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -7,6 +7,18 @@ if (LINUX)
     endif()
 endif()
 
+##================================================
+## API tokens
+##================================================
+if (DEFINED ENV{API_ID} AND DEFINED ENV{API_HASH})
+    set(API_ID ENV{API_ID})
+    set(API_HASH ENV{API_HASH})
+else()
+    message(WARNING "No custom API tokens detected. You must grab your own tokens from https://core.telegram.org/api/obtaining_api_id and export them using environment options. Will use default for testing purposes.")
+    set(API_ID 17349)
+    set(API_HASH "344583e45741c457fe1862106095a5eb")
+endif()
+
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -H")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 ##================================================

--- a/Telegram/SourceFiles/config.h.in
+++ b/Telegram/SourceFiles/config.h.in
@@ -206,12 +206,8 @@ w/CVnbwQOw0g5GBwwFV3r0uTTvy44xx8XXxk+Qknu4eBCsmrAFNnAgMBAAE=\n\
 -----END RSA PUBLIC KEY-----\
 ";
 
-#ifdef CUSTOM_API_ID
-#include "../../../TelegramPrivate/custom_api_id.h" // Custom API id and API hash
-#else
-static const qint32 ApiId = 17349;
-static const char *ApiHash = "344583e45741c457fe1862106095a5eb";
-#endif
+constexpr auto ApiId = @API_ID@;
+constexpr auto ApiHash = "@API_HASH@";
 
 #if Q_BYTE_ORDER == Q_BIG_ENDIAN
 #warning "Big endian support in Kepka is experimental. Proceed with caution!"


### PR DESCRIPTION
You can obtain your tokens from https://core.telegram.org/api/obtaining_api_id.

Export API_ID and API_TOKEN environment options with your tokens before
running Cmake to use them.