### PR TITLE
Travis build: invoke `git diff` once

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -6,11 +6,6 @@ cmake -G Ninja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $EXTRA_CMAKE_FLAGS -DBUILD_TESTING
 # grep returns number of items found. each change is enclosed into <replacement>
 # tag in the xml. Thus if no changes needed, 0 will be returned
 cmake --build . --target clang-format -- -v
-if [[ $(git diff) ]]; then
-    git diff | cat
-    exit 1
-else
-    echo "Success!"
-fi
+git diff --exit-code && echo "Success!" || exit 1
 cmake --build . -- -v || exit 1
 ASAN_OPTIONS=alloc_dealloc_mismatch=0 ctest . || exit 1


### PR DESCRIPTION
There's no need to check `git diff`'s output to see if it printed out anything—Git already provides an option to indicate that through the exit code.